### PR TITLE
Update CSI Docs

### DIFF
--- a/docs/using-cinder-csi-plugin.md
+++ b/docs/using-cinder-csi-plugin.md
@@ -4,7 +4,7 @@
 
 ### Requirements
 
-The following feature gates and runtime config have to be enabled to deploy the driver.
+Enable Following features gates for kubernetes cluster running versions lower than v1.10.
 
 ```
 FEATURE_GATES=CSIPersistentVolume=true,MountPropagation=true
@@ -12,6 +12,8 @@ RUNTIME_CONFIG="storage.k8s.io/v1alpha1=true"
 ```
 
 MountPropagation requires support for privileged containers. So, make sure privileged containers are enabled in the cluster.
+
+Check [kubernetes CSI Docs](https://kubernetes-csi.github.io/docs/) for flag details and latest update.
 
 ### Example local-up-cluster.sh
 


### PR DESCRIPTION

<!-- Thanks for sending a pull request! -->

**What this PR does / why we need it**:
CSIPersistentVolume and MountPropagation Feature gates are default enabled from kubernetes v1.10, updating CSI docs for the same.


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Reference: https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/

**Release note**:
`NONE`.
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
